### PR TITLE
chore: fix invalid version code err in release, closes #3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,13 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+-*'
+  pull_request:
+    branches:
+      - '**'
 
 jobs:
   build-and-release:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -50,8 +54,9 @@ jobs:
       - name: Sync Android version with package.json
         run: |
           PKG_VERSION=$(node -p "require('./package.json').version")
-          VERSION_CODE=$(echo $PKG_VERSION | grep -oE '[0-9]+' | tail -1)
-          if [ -z "$VERSION_CODE" ]; then VERSION_CODE=1; fi
+          # Convert version (e.g., 1.2.3) to versionCode (e.g., 10203)
+          VERSION_CODE=$(echo "$PKG_VERSION" | awk -F. '{ printf("%d%02d%02d", $1,$2,$3) }')
+          if [ -z "$VERSION_CODE" ] || [ "$VERSION_CODE" -le 0 ]; then VERSION_CODE=1; fi
           sed -i "s/versionName \".*\"/versionName \"$PKG_VERSION\"/" android/app/build.gradle
           sed -i "s/versionCode [0-9]\+/versionCode $VERSION_CODE/" android/app/build.gradle
         shell: bash
@@ -85,3 +90,33 @@ jobs:
           files: ${{ steps.apk.outputs.apk_path }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-on-pr:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Build Android APK (unsigned, for PR)
+        run: npm run build:android:release
+
+      - name: Archive APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-apk
+          path: android/app/build/outputs/apk/release/*.apk


### PR DESCRIPTION
## Context

To fix following build error - 
> FAILURE: Build failed with an exception.
> 
> * Where:
> Build file '/home/runner/work/GlutenBurg/GlutenBurg/android/build.gradle' line: 21
> 
> * What went wrong:
> A problem occurred evaluating root project 'glutenburg'.
> > Failed to apply plugin 'com.facebook.react.rootproject'.
>    > A problem occurred configuring project ':app'.
>       > android.defaultConfig.versionCode is set to 0, but it should be a positive integer.
>         See https://developer.android.com/studio/publish/versioning#appversioning for more information.
> 
> * Try:
> > Run with --stacktrace option to get the stack trace.
> > Run with --info or --debug option to get more log output.
> > Run with --scan to get full insights.
> > Get more help at https://help.gradle.org./
> 
> BUILD FAILED in 1m 42s
> [Incubating] Problems report is available at: file:///home/runner/work/GlutenBurg/GlutenBurg/android/build/reports/problems/problems-report.html
> 
> Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.
> 
> You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.
> 
> For more on this, please refer to https://docs.gradle.org/8.13/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.
> 10 actionable tasks: 10 executed

[ :heavy_check_mark: ] chore: fix invalid version code err in release, closes #3