### PR TITLE
fix: language select improper height, closes #7

### DIFF
--- a/components/BookSearch.js
+++ b/components/BookSearch.js
@@ -32,11 +32,11 @@ const FiltersPanel = React.memo(({ options, handleFilterChange, styles }) => {
       </View>
       <View style={styles.filterRow}>
         <Text style={styles.filterLabel}>Languages:</Text>
-        <View style={{ flex: 1, borderRadius: 6, backgroundColor: THEME.BACKGROUND, borderWidth: 1, borderColor: THEME.SURFACE1, height: 50, justifyContent: 'center' }}>
+        <View style={{ flex: 1, borderRadius: 6, backgroundColor: THEME.BACKGROUND, borderWidth: 1, borderColor: THEME.SURFACE1, justifyContent: 'center' }}>
           <Picker
             selectedValue={languageValue}
             onValueChange={v => handleFilterChange('languages', v)}
-            style={{ flex: 1, color: THEME.BLUE, height: 40, margin: 0, padding: 0 }}
+            style={{ width: '100%', color: THEME.BLUE, minWidth: 0 }}
             dropdownIconColor={THEME.BLUE}
             mode='dialog'
           >


### PR DESCRIPTION
## Context

Language select height gets cut in certain devices. 

## Before

![Image](https://github.com/user-attachments/assets/09c7204b-5351-468b-9aa9-2f6044dd71f9)

## After

![image](https://github.com/user-attachments/assets/30b79a1f-a61d-4e00-9ad7-a55b5ebead59)

[ :heavy_check_mark: ] fix: language select improper height, closes #7