### PR TITLE
fix: filter placeholder color not respecting theme, closes #9

### DIFF
--- a/components/BookSearch.js
+++ b/components/BookSearch.js
@@ -18,6 +18,7 @@ const FiltersPanel = React.memo(({ options, handleFilterChange, styles }) => {
           placeholder='E.g. 1800'
           value={options.author_year_start ? String(options.author_year_start) : ''}
           onChangeText={v => handleFilterChange('author_year_start', v ? parseInt(v, 10) : undefined)}
+          placeholderTextColor={THEME.SECONDARY_TEXT}
         />
       </View>
       <View style={styles.filterRow}>
@@ -28,6 +29,7 @@ const FiltersPanel = React.memo(({ options, handleFilterChange, styles }) => {
           placeholder='E.g. 1899'
           value={options.author_year_end ? String(options.author_year_end) : ''}
           onChangeText={v => handleFilterChange('author_year_end', v ? parseInt(v, 10) : undefined)}
+          placeholderTextColor={THEME.SECONDARY_TEXT}
         />
       </View>
       <View style={styles.filterRow}>
@@ -54,6 +56,7 @@ const FiltersPanel = React.memo(({ options, handleFilterChange, styles }) => {
           placeholder='E.g. Fiction, Science, History'
           value={options.topic || ''}
           onChangeText={v => handleFilterChange('topic', v)}
+          placeholderTextColor={THEME.SECONDARY_TEXT}
         />
       </View>
     </View>


### PR DESCRIPTION
## Context

To fix filter placeholder colors not respecting theme.

## Before

![Image](https://github.com/user-attachments/assets/dbac9958-088a-4aa8-b2c7-e57c7901d9b5)

## After

![image](https://github.com/user-attachments/assets/d26ff76d-4061-41c5-b8b5-9b466fe7bf23)


[ :heavy_check_mark: ] fix: filter placeholder color not respecting theme, closes #9