### PR TITLE
fix: book detail not showing full cover, closes #11

### DIFF
--- a/components/BookDetail.js
+++ b/components/BookDetail.js
@@ -34,7 +34,7 @@ export const BookDetail = ({ route }) => {
       <Animated.Image
         source={{ uri: cover }}
         style={styles.cover}
-        resizeMode='cover'
+        resizeMode='contain'
         sharedTransitionTag={`item.${book.id}.cover`}
       />
       <Animated.View entering={FadeIn.delay(500).duration(400)}>
@@ -83,7 +83,7 @@ export const BookDetail = ({ route }) => {
 const styles = StyleSheet.create({
   cover: {
     width: '100%',
-    height: 260,
+    aspectRatio: 2 / 3,
     borderRadius: 10,
     marginBottom: 18,
     backgroundColor: THEME.SURFACE1,


### PR DESCRIPTION
## Context

Book detail view not showing full cover.

## Before

![Image](https://github.com/user-attachments/assets/b681ad36-c8d5-4040-b8cb-afc9b5864fa3)

## After

![image](https://github.com/user-attachments/assets/0470253f-dc8b-443a-8254-2b036367f3ef)

[ :heavy_check_mark: ] fix: book detail not showing full cover, closes #11
