### PR TITLE
chore: fix build-on-pr workflow for signing, closes #17 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,11 +112,11 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
-      - name: Build Android APK (unsigned, for PR)
-        run: npm run build:android:release
+      - name: Build Android APK (debug, for PR)
+        run: cd android && ./gradlew assembleDebug && cd ..
 
       - name: Archive APK artifact
         uses: actions/upload-artifact@v4
         with:
           name: pr-apk
-          path: android/app/build/outputs/apk/release/*.apk
+          path: android/app/build/outputs/apk/debug/*.apk


### PR DESCRIPTION
# Context

build-on-pr workflow is failing with the following note - 
```
[Incubating] Problems report is available at: file:///home/runner/work/GlutenBurg/GlutenBurg/android/build/reports/problems/problems-report.html

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:packageRelease'.
> A failure occurred while executing com.android.build.gradle.tasks.PackageAndroidArtifact$IncrementalSplitterRunnable
   > SigningConfig "release" is missing required property "storeFile".

```

This PR fixes it by utilizing assembleDebug.

[ :heavy_check_mark: ] chore: fix build-on-pr workflow for signing, closes #17 