### PR TITLE
test: added tests for skeleton book card, closes #32

### DIFF
--- a/__tests__/SkeletonBookCard.test.js
+++ b/__tests__/SkeletonBookCard.test.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import { render } from '@testing-library/react-native'
+import { SkeletonBookCard } from '../components/SkeletonBookCard'
+
+describe('SkeletonBookCard', () => {
+  it('renders the skeleton book card container', () => {
+    const { getByTestId } = render(<SkeletonBookCard />)
+    expect(getByTestId('skeleton-book-card')).toBeTruthy()
+  })
+
+  it('renders BookCard in skeleton mode', () => {
+    const { UNSAFE_queryByProps } = render(<SkeletonBookCard />)
+    expect(UNSAFE_queryByProps({ skeleton: true })).not.toBeNull()
+  })
+})

--- a/components/SkeletonBookCard.js
+++ b/components/SkeletonBookCard.js
@@ -3,7 +3,7 @@ import { View } from 'react-native'
 import { BookCard } from './BookCard'
 
 const SkeletonBookCard = () => (
-  <View style={{ flex: 1, margin: 8 }}>
+  <View style={{ flex: 1, margin: 8 }} testID='skeleton-book-card'>
     <BookCard skeleton />
   </View>
 )


### PR DESCRIPTION
### SkeletonBookCard.test.js Test Coverage

- [x] Renders the skeleton book card container
- [x] Renders BookCard in skeleton mode

```
 PASS  __tests__/SkeletonBookCard.test.js
  SkeletonBookCard
    ✓ renders the skeleton book card container (11 ms)
    ✓ renders BookCard in skeleton mode (6 ms)

Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Snapshots:   0 total
Time:        0.55 s, estimated 1 s
```

[ :heavy_check_mark: ] test: added tests for skeleton book card, closes #32