### PR TITLE
test: added tests for error view, closes #32

### DIFF
--- a/__tests__/ErrorView.test.js
+++ b/__tests__/ErrorView.test.js
@@ -1,0 +1,11 @@
+import React from 'react'
+import { render } from '@testing-library/react-native'
+import { ErrorView } from '../components/ErrorView'
+
+describe('ErrorView', () => {
+  it('renders the error message', () => {
+    const message = 'Something went wrong!'
+    const { getByText } = render(<ErrorView message={message} />)
+    expect(getByText(message)).toBeTruthy()
+  })
+})


### PR DESCRIPTION
### ErrorView.test.js Test Coverage

- [x] Renders the error message

```
 PASS  __tests__/ErrorView.test.js
  ErrorView
    ✓ renders the error message (6 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        0.428 s, estimated 1 s
```

[ :heavy_check_mark: ] test: added tests for error view, closes #30